### PR TITLE
Fix device whitelisting for preflight calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mxd-cors",
   "description": "Initialized cors middlewares for the maxdome devices",
-  "version": "2.9.2",
+  "version": "2.9.3",
   "readmeFilename": "README.md",
   "main": "src/lib.js",
   "scripts": {

--- a/src/lib.js
+++ b/src/lib.js
@@ -18,6 +18,7 @@ module.exports = (opts) => {
           allowedHeaders: ['accept', 'content-type', 'platform', 'clienttype', 'x-device'],
           maxAge: 3600,
           optionsSuccessStatus: 200, // some legacy browsers (IE11, various SmartTVs) choke on 204
+          preflightContinue: true
         },
         opts,
         (objValue, srcValue) => {
@@ -28,17 +29,24 @@ module.exports = (opts) => {
       )
     )(req, res, (err) => {
       if (err) {
-        next(err);
-      } else {
-        const devices = ['Media/BP440', 'Media/BP530', 'Media/BP540', 'Media/BH6430', 'Media/BP550', 'Media/BP730'];
-        if (req.headers['platform'] === 'ott' && req.headers['clienttype'] === 'lg_bd' && devices.indexOf(req.headers['x-device']) > -1) {
-          res.setHeader('access-control-allow-origin', '*');
-          res.removeHeader('access-control-allow-credentials');
-        } else if (res.get('access-control-allow-origin') === undefined && res.get('access-control-allow-credentials') !== undefined) {
-          res.removeHeader('access-control-allow-credentials');
-        }
-        next();
+        return next(err);
       }
+
+      const method = req.method && req.method.toUpperCase && req.method.toUpperCase();
+      const devices = ['Media/BP440', 'Media/BP530', 'Media/BP540', 'Media/BH6430', 'Media/BP550', 'Media/BP730'];
+
+      if (req.headers['platform'] === 'ott' && req.headers['clienttype'] === 'lg_bd' && devices.indexOf(req.headers['x-device']) > -1) {
+        res.setHeader('access-control-allow-origin', '*');
+        res.removeHeader('access-control-allow-credentials');
+      } else if (res.get('access-control-allow-origin') === undefined && res.get('access-control-allow-credentials') !== undefined) {
+        res.removeHeader('access-control-allow-credentials');
+      }
+
+      if (method === 'OPTIONS') {
+        return res.status(200).end();
+      }
+
+      return next();
     });
   };
 };


### PR DESCRIPTION
Whitelisting was not done for OPTIONS calls since `next` is not executed in `cors` module without `preflightContinue` option set (see https://github.com/expressjs/cors/blob/master/lib/index.js#L171).